### PR TITLE
feat: external outputs support with ddc i2c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get -y install v4l-utils libv4l-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev
       - run: make test
 
   lint:
@@ -19,5 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get -y install v4l-utils libv4l-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev
       - run: make lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
- "memchr",
+ "memchr 2.4.1",
 ]
 
 [[package]]
@@ -19,6 +19,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "ash"
@@ -76,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,7 +99,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -136,6 +148,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys 0.8.3",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "ddc"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba69f2c53e320fc4abad17cb02bbbf04d1a36f18e9907f347589ec5991b3c6c5"
+dependencies = [
+ "mccs",
+]
+
+[[package]]
+name = "ddc-hi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6747b17c926a2aa34739b30f1a6cc726e3a7baf0e2f69a4c03a95cf5de94de"
+dependencies = [
+ "anyhow",
+ "ddc",
+ "ddc-i2c",
+ "ddc-macos",
+ "ddc-winapi",
+ "edid",
+ "log",
+ "mccs",
+ "mccs-caps",
+ "mccs-db",
+ "nvapi",
+]
+
+[[package]]
+name = "ddc-i2c"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66503057bd41fc21b532b3ebe33b2ec57e5d4971fcfc3844306ebcb499b6c8c2"
+dependencies = [
+ "ddc",
+ "i2c",
+ "i2c-linux",
+ "resize-slice",
+]
+
+[[package]]
+name = "ddc-macos"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbaf316c113cfc30da8856c8104dfb4168b73fdd78562d1542e358fe8299dea"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys 0.8.3",
+ "core-graphics",
+ "ddc",
+ "io-kit-sys",
+ "mach 0.3.2",
+ "thiserror",
+]
+
+[[package]]
+name = "ddc-winapi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3238e71b65c870e236de529546a689202fca64a2eaeec43995d28f6920d7fc9e"
+dependencies = [
+ "ddc",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +297,21 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "edid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ce75530893d834dcfe3bb67ce0e7dec489484e7cb4423ca31618af4bab24fe"
+dependencies = [
+ "nom 3.2.1",
+]
 
 [[package]]
 name = "either"
@@ -213,6 +353,21 @@ checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fragile"
@@ -259,6 +414,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "i2c"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7b7bdd7b3a985fdcf94a0d7d98e7a47fde8b7f22fb55ce1a91cc104a2ce9a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "i2c-linux"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0268a871aaa071221d6c2875ebedcf64710e59b0d87c68c8faf5e98b87dd2a4"
+dependencies = [
+ "bitflags",
+ "i2c",
+ "i2c-linux-sys",
+ "resize-slice",
+ "udev",
+]
+
+[[package]]
+name = "i2c-linux-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b70fd3d30157850c87f4c7c09c0857d9c2e8c996bcbe23ec1299126e0479ec"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "libc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +454,16 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21dcc74995dd4cd090b147e79789f8d65959cbfb5f0b118002db869ea3bd0a0"
+dependencies = [
+ "core-foundation-sys 0.6.2",
+ "mach 0.2.3",
 ]
 
 [[package]]
@@ -306,6 +504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +526,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "mach"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mccs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74366c6da4179141e0d4551a46799a7e667a68eda60561690d5048bd8e0f8422"
+dependencies = [
+ "void",
+]
+
+[[package]]
+name = "mccs-caps"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9766b1345aec53f3f1781797e31f7367a8c53871a0e30214d8372fe2ccbe3ce"
+dependencies = [
+ "mccs",
+ "nom 3.2.1",
+]
+
+[[package]]
+name = "mccs-db"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99726fbbe1e11e2908c461e8fab6c9106a5cb13338cc4feb68a01cced38026d0"
+dependencies = [
+ "mccs",
+ "nom 3.2.1",
+ "serde",
+ "serde_derive",
+ "serde_yaml 0.7.5",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -377,11 +644,20 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+dependencies = [
+ "memchr 1.0.2",
+]
+
+[[package]]
+name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "memchr",
+ "memchr 2.4.1",
  "version_check",
 ]
 
@@ -408,6 +684,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nvapi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c3253cb48b2bdaea1168730a32790a8c3deb5481d14b21028a9f6a548e803c"
+dependencies = [
+ "i2c",
+ "log",
+ "nvapi-sys",
+ "void",
+]
+
+[[package]]
+name = "nvapi-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29e9a9393c69ee856bfcf5f76ed1ef32d2c0dd6f58558fd43334278fc1e7ea7"
+dependencies = [
+ "bitflags",
+ "winapi",
 ]
 
 [[package]]
@@ -501,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
- "memchr",
+ "memchr 2.4.1",
  "regex-syntax",
 ]
 
@@ -510,6 +808,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "resize-slice"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3cb2f74a9891e76958b9e0ccd269a25b466c3ae3bb3efd71db157248308c4a"
+dependencies = [
+ "uninitialized",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -541,6 +848,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -609,6 +928,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +966,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "udev"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47504d1a49b2ea1b133e7ddd1d9f0a83cf03feb9b440c2c470d06db4589cf301"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +986,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "uninitialized"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c1aa4511c38276c548406f0b1f5f8b793f000cfb51e18f278a102abd057e81"
 
 [[package]]
 name = "v4l"
@@ -669,6 +1024,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
@@ -745,6 +1106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a212922ea58fbf5044f83663aa4fc6281ff890f1fd7546c0c3f52f5290831781"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,13 +1148,14 @@ version = "2.0.1"
 dependencies = [
  "ash",
  "chrono",
+ "ddc-hi",
  "dirs",
  "env_logger 0.9.0",
  "itertools",
  "log",
  "mockall",
  "serde",
- "serde_yaml",
+ "serde_yaml 0.8.23",
  "toml",
  "v4l",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ ash = "0.33"
 itertools = "0.10"
 mockall = "0.10"
 v4l = { version = "0.12", features = ["libv4l"], default-features = false }
+ddc-hi = "0.4"
 log = "0.4"
 env_logger = "0.9"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simply launch `wluma` and continue adjusting your screen brightness as you usual
 
 ## Performance
 
-The app has minimal impact on system resources and battery life even though it is able to monitor screen contents several times a second. This is achieved by using [export-dmabuf](https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-export-dmabuf-unstable-v1.xml) Wayland protocol to get access to the screen contents and doing computations entirely on GPU using Vulkan API.
+The app has minimal impact on system resources and battery life even though it is able to monitor screen contents several times a second. This is achieved by using [export-dmabuf](https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/blob/master/unstable/wlr-export-dmabuf-unstable-v1.xml) Wayland protocol to get access to the screen contents and doing computations entirely on GPU using Vulkan API.
 
 ## Installation
 

--- a/config.toml
+++ b/config.toml
@@ -21,13 +21,16 @@ thresholds = [ 20, 80, 250, 500, 800 ]
 path = "/sys/class/backlight/intel_backlight"
 # use_contents = true # TODO will be relevant in multi-monitor setups
 
-##############################################################################
-# TODO everything below is an idea, not supported but definitely wanted!
+###################################################################
+# to get DP-1 and ABCDEFG you can use `swaymsg -t get_outputs` in
+# running sway.
+# #################################################################
 #
 # [output.ddcutil.DP-1]
-# display = 1
+# serial_number = "ABCDEFG"
 # use_contents = false
 #
+# TODO everything below is an idea, not supported but definitely wanted!
 # [keyboard.backlight.dell]
 # path = "/sys/bus/platform/devices/dell-laptop/leds/dell::kbd_backlight"
 #

--- a/src/als/webcam.rs
+++ b/src/als/webcam.rs
@@ -80,8 +80,12 @@ impl Als {
 
 impl super::Als for Als {
     fn get_raw(&self) -> Result<u64, Box<dyn Error>> {
-        let value = *self.lux.borrow();
-        *self.lux.borrow_mut() = self.webcam_rx.try_iter().last().unwrap_or(value);
+        let value = self
+            .webcam_rx
+            .try_iter()
+            .last()
+            .unwrap_or(*self.lux.borrow());
+        *self.lux.borrow_mut() = value;
         Ok(value)
     }
 

--- a/src/als/webcam.rs
+++ b/src/als/webcam.rs
@@ -81,13 +81,13 @@ impl Als {
 
 impl super::Als for Als {
     fn get_raw(&self) -> Result<u64, Box<dyn Error>> {
-        let value = self
+        let new_value = self
             .webcam_rx
             .try_iter()
             .last()
             .unwrap_or(*self.lux.borrow());
-        *self.lux.borrow_mut() = value;
-        Ok(value)
+        *self.lux.borrow_mut() = new_value;
+        Ok(new_value)
     }
 
     fn smoothen(&self, raw: u64) -> u64 {

--- a/src/als/webcam.rs
+++ b/src/als/webcam.rs
@@ -30,22 +30,23 @@ impl Webcam {
         }
     }
 
-    pub fn run(&mut self) -> Result<(), Box<dyn Error>> {
+    pub fn run(&mut self) {
         loop {
-            self.step()?;
+            self.step();
         }
     }
 
-    fn step(&mut self) -> Result<(), Box<dyn Error>> {
+    fn step(&mut self) {
         if let Ok((rgbs, pixels)) = self.frame() {
             let lux_raw = compute_perceived_lightness_percent(&rgbs, false, pixels) as u64;
             let lux = self.kalman.process(lux_raw);
 
-            self.webcam_tx.send(lux)?;
+            self.webcam_tx
+                .send(lux)
+                .expect("Unable to send new webcam lux value, channel is dead");
         };
 
         thread::sleep(Duration::from_millis(WAITING_SLEEP_MS));
-        Ok(())
     }
 
     fn frame(&mut self) -> Result<(Vec<u8>, usize), Box<dyn Error>> {

--- a/src/als/webcam.rs
+++ b/src/als/webcam.rs
@@ -80,12 +80,9 @@ impl Als {
 
 impl super::Als for Als {
     fn get_raw(&self) -> Result<u64, Box<dyn Error>> {
-        *self.lux.borrow_mut() = self
-            .webcam_rx
-            .try_iter()
-            .last()
-            .unwrap_or(*self.lux.borrow());
-        Ok(*self.lux.borrow())
+        let value = *self.lux.borrow();
+        *self.lux.borrow_mut() = self.webcam_rx.try_iter().last().unwrap_or(value);
+        Ok(value)
     }
 
     fn smoothen(&self, raw: u64) -> u64 {

--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -29,11 +29,11 @@ impl Backlight {
 }
 
 impl super::Brightness for Backlight {
-    fn get(&mut self) -> Result<u64, Box<dyn Error>> {
+    fn get(&self) -> Result<u64, Box<dyn Error>> {
         Ok(read(&mut self.file.borrow_mut())? as u64)
     }
 
-    fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>> {
+    fn set(&self, value: u64) -> Result<u64, Box<dyn Error>> {
         let value = value.max(1).min(self.max_brightness);
         write(&mut self.file.borrow_mut(), value as f64)?;
         Ok(value)

--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -29,11 +29,11 @@ impl Backlight {
 }
 
 impl super::Brightness for Backlight {
-    fn get(&self) -> Result<u64, Box<dyn Error>> {
+    fn get(&mut self) -> Result<u64, Box<dyn Error>> {
         Ok(read(&mut self.file.borrow_mut())? as u64)
     }
 
-    fn set(&self, value: u64) -> Result<u64, Box<dyn Error>> {
+    fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>> {
         let value = value.max(1).min(self.max_brightness);
         write(&mut self.file.borrow_mut(), value as f64)?;
         Ok(value)

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -145,7 +145,7 @@ mod tests {
         prediction_tx.send(37)?;
 
         // when we execute the first step...
-        controller.step()?;
+        controller.step();
 
         // a real current brightness level is respected and sent to predictor
         assert_eq!(42, controller.current);
@@ -171,7 +171,7 @@ mod tests {
         controller.target = Some(target(77, 1));
 
         // when we execute the next step...
-        controller.step()?;
+        controller.step();
 
         // we notice a change in brightness made by user and that takes priority
         assert_eq!(42, controller.current);

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -66,7 +66,7 @@ impl Controller {
             // 3. continue the transition if there is one in progress
             if self.target.is_some() {
                 if let Err(err) = self.transition() {
-                    println!("Can't transition brightness: {:?}", err);
+                    log::error!("Can't transition brightness: {:?}", err);
                 };
                 return;
             }

--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -40,7 +40,7 @@ impl super::Brightness for DdcUtil {
 }
 
 fn get_max_brightness(display: &mut Display) -> Result<u64, Box<dyn Error>> {
-    Ok(display.handle.get_vcp_feature(0x10).unwrap().maximum() as u64)
+    Ok(display.handle.get_vcp_feature(0x10)?.maximum() as u64)
 }
 
 fn find_display_by_sn(serial_number: &str) -> Option<Display> {

--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -1,0 +1,50 @@
+use ddc_hi;
+use ddc_hi::{Ddc, Display};
+use std::error::Error;
+
+pub struct DdcUtil {
+    display: Display,
+    max_brightness: u64,
+}
+
+impl DdcUtil {
+    pub fn new(serial_number: &str) -> Result<Self, Box<dyn Error>> {
+        let mut display = find_display_by_sn(serial_number).ok_or("Unable to find display")?;
+        let max_brightness = get_max_brightness(&mut display)?;
+
+        Ok(Self {
+            display,
+            max_brightness,
+        })
+    }
+}
+
+impl super::Brightness for DdcUtil {
+    fn get(&mut self) -> Result<u64, Box<dyn Error>> {
+        Ok(self.display.handle.get_vcp_feature(0x10)?.value() as u64)
+    }
+
+    fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>> {
+        let value = value.max(1).min(self.max_brightness);
+        self.display.handle.set_vcp_feature(0x10, value as u16)?;
+        Ok(value)
+    }
+}
+
+fn get_max_brightness(display: &mut Display) -> Result<u64, Box<dyn Error>> {
+    Ok(display.handle.get_vcp_feature(0x10).unwrap().maximum() as u64)
+}
+
+fn find_display_by_sn(serial_number: &str) -> Option<Display> {
+    ddc_hi::Display::enumerate()
+        .into_iter()
+        .find_map(|mut display| {
+            display
+                .info
+                .serial_number
+                .as_ref()
+                .map(|v| v == serial_number)
+                .and_then(|_| display.update_capabilities().ok())
+                .and_then(|_| Some(display))
+        })
+}

--- a/src/brightness/mod.rs
+++ b/src/brightness/mod.rs
@@ -3,12 +3,14 @@ use std::error::Error;
 
 mod backlight;
 mod controller;
+mod ddcutil;
 
 pub use backlight::Backlight;
 pub use controller::Controller;
+pub use ddcutil::DdcUtil;
 
 #[automock]
 pub trait Brightness {
-    fn get(&self) -> Result<u64, Box<dyn Error>>;
-    fn set(&self, value: u64) -> Result<u64, Box<dyn Error>>;
+    fn get(&mut self) -> Result<u64, Box<dyn Error>>;
+    fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>>;
 }

--- a/src/brightness/mod.rs
+++ b/src/brightness/mod.rs
@@ -11,6 +11,6 @@ pub use ddcutil::DdcUtil;
 
 #[automock]
 pub trait Brightness {
-    fn get(&mut self) -> Result<u64, Box<dyn Error>>;
-    fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>>;
+    fn get(&self) -> Result<u64, Box<dyn Error>>;
+    fn set(&self, value: u64) -> Result<u64, Box<dyn Error>>;
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub struct BacklightOutput {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct DdcUtilOutput {
-    pub display: u8,
+    pub serial_number: String,
     #[serde(default)]
     pub use_contents: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,7 @@ fn main() {
         config::Als::Webcam { video, thresholds } => Box::new({
             let (webcam_tx, webcam_rx) = mpsc::channel();
             std::thread::spawn(move || {
-                als::webcam::Webcam::new(webcam_tx, video)
-                    .run()
-                    .expect("Error running ALS webcam background thread");
+                als::webcam::Webcam::new(webcam_tx, video).run();
             });
 
             als::webcam::Als::new(webcam_rx, thresholds)


### PR DESCRIPTION
This PR add support of external screen, dont forgot to enable DDC in monitor settings in necessary.
Can also need to load `modprobe i2c-dev` and give good permissions.

With archlinux `ddcutil` package will be need. Also add your user to `i2c` group and restart thereafter.
This will allow to ajust the brightness with `ddcutil -d 1 setvcp 0x10 75` where 75 is percentil value you want.
