### PR TITLE
fix: ddcutil serial_number not needed anymore in config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,6 @@ pub struct BacklightOutput {
 #[derive(Deserialize, Debug, Clone)]
 pub struct DdcUtilOutput {
     pub name: String,
-    pub serial_number: String,
     #[serde(default)]
     pub use_contents: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
                                     .expect("Unable to initialize output backlight"),
                             ),
                             config::Output::DdcUtil(cfg) => Box::new(
-                                brightness::DdcUtil::new(&cfg.serial_number)
+                                brightness::DdcUtil::new(&cfg.name)
                                     .expect("Unable to initialize output ddcutil"),
                             ),
                         };


### PR DESCRIPTION
put serial number in `name` field if needed