### PR TITLE
Logind fallback support for unprivileged users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev
+      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev libdbus-1-dev
       - run: make test
 
   lint:
@@ -21,5 +21,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update
-      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev
+      - run: sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev libdbus-1-dev
       - run: make lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ddc"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +610,15 @@ name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -1458,6 +1478,7 @@ version = "4.3.0"
 dependencies = [
  "ash",
  "chrono",
+ "dbus",
  "ddc-hi",
  "env_logger",
  "inotify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.9"
 inotify = "0.10"
 lazy_static = "1.4"
 xdg = "2.4.1"
+dbus = "0.9.7"
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Then simply run `make build`.
 
 ## Permissions
 
-In order to access backlight devices, `wluma` must either run as `root`, or preferrably instead you should add your user to `video` group in combination with installing the supplied `90-wluma-backlight.rules` udev rule (don't forget to reboot thereafter).
+In order to access backlight devices, `wluma` must either:
 
-Alternatively, the above steps are not required if your system uses `elogind` or `systemd-logind` as they provide a safe interface for unprivileged users to control device's brightness through `dbus`.
+- have direct driver access: install the supplied `90-wluma-backlight.rules` udev rule, add your user to the `video` group and reboot (fastest)
+- run on a system that uses `elogind` or `systemd-logind` (they provide a safe interface for unprivileged users to control device's brightness through `dbus`, no configuration necessary)
+- run as `root` (not recommended)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use one of the available packages and methods below:
 
 [![CI](https://github.com/maximbaz/wluma/actions/workflows/ci.yml/badge.svg)](https://github.com/maximbaz/wluma/actions/workflows/ci.yml)
 
-If you want to build the app yourself, make sure you use latest stable Rust, otherwise you might get compilation errors! Using `rustup` is perhaps the easiest. Ubuntu needs the following dependencies: `sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev`.
+If you want to build the app yourself, make sure you use latest stable Rust, otherwise you might get compilation errors! Using `rustup` is perhaps the easiest. Ubuntu needs the following dependencies: `sudo apt-get -y install v4l-utils libv4l-dev libudev-dev libvulkan-dev libdbus-1-dev`.
 
 Then simply run `make build`.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Then simply run `make build`.
 
 In order to access backlight devices, `wluma` must either run as `root`, or preferrably instead you should add your user to `video` group in combination with installing the supplied `90-wluma-backlight.rules` udev rule (don't forget to reboot thereafter).
 
+Alternatively, the above steps are not required if your system uses `elogind` or `systemd-logind` as they provide a safe interface for unprivileged users to control device's brightness through `dbus`.
+
 ## Configuration
 
 The `config.toml` in repository represents default config values. To change them, copy the file into `$XDG_CONFIG_HOME/wluma/config.toml` and adjust as desired.

--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
 use std::path::Path;
+use dbus::{self, blocking::{BlockingSender, Connection}};
 
 pub struct Backlight {
     file: File,
@@ -12,10 +13,15 @@ pub struct Backlight {
     max_brightness: u64,
     inotify: Inotify,
     current: Option<u64>,
+    id: Option<String>,
+    class: Option<String>,
 }
 
 impl Backlight {
     pub fn new(path: &str, min_brightness: u64) -> Result<Self, Box<dyn Error>> {
+        let id = Path::new(path).file_name().map(|s| s.to_string_lossy().to_string());
+        let class = Path::new(path).parent().and_then(|p| p.file_name()).map(|s| s.to_string_lossy().to_string());
+
         let brightness_path = Path::new(path).join("brightness");
         let file = OpenOptions::new()
             .read(true)
@@ -40,6 +46,8 @@ impl Backlight {
             max_brightness,
             inotify,
             current: None,
+            id,
+            class
         })
     }
 }
@@ -70,7 +78,22 @@ impl super::Brightness for Backlight {
     fn set(&mut self, value: u64) -> Result<u64, Box<dyn Error>> {
         let value = value.clamp(self.min_brightness, self.max_brightness);
 
-        write(&mut self.file, value as f64)?;
+        if write(&mut self.file, value as f64).is_err() {
+            if let (Some(class), Some(id)) = (&self.class, &self.id) {
+                let conn = Connection::new_system()?;
+                let msg = dbus::Message::new_method_call(
+                    "org.freedesktop.login1",
+                    "/org/freedesktop/login1/session/auto",
+                    "org.freedesktop.login1.Session",
+                    "SetBrightness",
+                )?
+                    .append2(class, id)
+                    .append1(value as u32);
+
+                conn.send_with_reply_and_block(msg, std::time::Duration::from_secs(1))?;
+            }
+        }
+
         self.current = Some(value);
 
         // Consume file events to not trigger get() update

--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -5,7 +5,9 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
 use std::path::Path;
-use dbus::{self, blocking::Connection, Message, channel::Sender};
+use std::time::Duration;
+use dbus::{self, blocking::Connection, Message};
+use dbus::blocking::BlockingSender;
 
 pub struct Backlight {
     file: File,
@@ -95,7 +97,7 @@ impl super::Brightness for Backlight {
                 .duplicate()?
                 .append1(value as u32);
 
-            conn.send(msg).unwrap();
+            conn.send_with_reply_and_block(msg, Duration::from_millis(100))?;
         } else {
             Err(std::io::Error::from(ErrorKind::PermissionDenied))?
         }

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -103,7 +103,7 @@ impl Controller {
                 if target.reached(current) {
                     self.target = None;
                 } else {
-                    let new_value = (current as i64 + target.step).max(0) as u64;
+                    let new_value = current.saturating_add_signed(target.step);
                     match self.brightness.set(new_value) {
                         Ok(new_value) => self.current = Some(new_value),
                         Err(err) => log::error!(


### PR DESCRIPTION
`elogind` or `systemd-logind` provide a safe interface for unprivileged users to control device's brightness through `dbus`. So I implemented support for setting backlight brightness when user is neither running program as `root` nor part of `video` group.

Unfortunately I've never used `wluma` myself and currently I am not able to. So this changes is not tested. But [this exact code](https://github.com/geekylthyosaur/slight/blob/master/src/device.rs#L63) works as expected in my own brightness control utility and I think support of `logind` fallback will be nice addition to `wluma` features.

[More info](https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html)