### PR TITLE
fix: give service access to fs

### DIFF
--- a/wluma.service
+++ b/wluma.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/wluma
 Restart=always
 EnvironmentFile=-%E/wluma/service.conf
 PrivateNetwork=true
+PrivateMounts=false
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
If `PrivateNetwork` is set, it also implicitly sets `PrivateMounts` to the value of `true`, in this patch we have explicitly set it to false.

related #92