### PR TITLE
add monitor detection fallback to skip cap check

### DIFF
--- a/src/predictor/data.rs
+++ b/src/predictor/data.rs
@@ -40,6 +40,7 @@ impl Data {
         Ok(OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(false)
             .read(true)
             .open(path)?)
     }


### PR DESCRIPTION
Resolves #101 

I'm a total Rust newb - if there's a better way to do this let me know. I basically copied everything from `find_display_by_name` and skipped the capabilities check. Not the prettiest but it's only twice. 

Personally, I'm a fan of "twice is not duplication" ;)