### PR TITLE
fix(ddcutil): add display manufacturer id

### DIFF
--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -77,19 +77,10 @@ fn find_display_by_name(name: &str, check_caps: bool) -> Option<Display> {
             caps.ok().map(|_| {
                 let empty = "".to_string();
                 let merged = format!(
-                    "{} {}",
-                    display
-                        .info
-                        .model_name
-                        .as_ref()
-                        .map_or(&empty, |model_name| {
-                            if model_name.starts_with(char::from(0)) {
-                                display.info.manufacturer_id.as_ref().unwrap_or(&empty)
-                            } else {
-                                model_name
-                            }
-                        }),
-                    display.info.serial_number.as_ref().unwrap_or(&empty)
+                    "{} {} {}",
+                    display.info.model_name.as_ref().unwrap_or(&empty),
+                    display.info.serial_number.as_ref().unwrap_or(&empty),
+                    display.info.manufacturer_id.as_ref().unwrap_or(&empty)
                 );
                 (merged, display)
             })

--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -78,7 +78,17 @@ fn find_display_by_name(name: &str, check_caps: bool) -> Option<Display> {
                 let empty = "".to_string();
                 let merged = format!(
                     "{} {}",
-                    display.info.model_name.as_ref().unwrap_or(&empty),
+                    display
+                        .info
+                        .model_name
+                        .as_ref()
+                        .map_or(&empty, |model_name| {
+                            if model_name.starts_with(char::from(0)) {
+                                display.info.manufacturer_id.as_ref().unwrap_or(&empty)
+                            } else {
+                                model_name
+                            }
+                        }),
                     display.info.serial_number.as_ref().unwrap_or(&empty)
                 );
                 (merged, display)


### PR DESCRIPTION
I was having a problem where wluma was not detecting the name of my auxiliary monitor, causing it to return `\0`, so I made it fallback to the manufactured id to be able to use wluma completely.

### *Before*:
```bash
2025-01-20T21:55:47Z DEBUG wluma::brightness::backlight] Using direct write on /sys/class/backlight/amdgpu_bl1 to change brightness value
[2025-01-20T21:55:47Z DEBUG wluma::frame::capturer::wayland] Detected support for linux-dmabuf-v1 protocol
[2025-01-20T21:55:47Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-export-dmabuf-unstable-v1 protocol
[2025-01-20T21:55:47Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-screencopy-unstable-v1 protocol
[2025-01-20T21:55:47Z DEBUG wluma::frame::capturer::wayland] Using output 'BOE 0x08D5 (eDP-1)' for config 'BOE'
[2025-01-20T21:55:47Z DEBUG wluma::frame::capturer::wayland] Using wlr-screencopy-unstable-v1 protocol to request frames
[2025-01-20T21:55:51Z DEBUG wluma::brightness::ddcutil] Discovered displays (check_caps=true): ["\0 "]
[2025-01-20T21:55:51Z DEBUG wluma::brightness::ddcutil] Using display ' ' for config 'RTK' (check_caps=true)
[2025-01-20T21:55:51Z INFO  wluma] Continue adjusting brightness and wluma will learn your preference over time.
[2025-01-20T21:55:51Z DEBUG wluma::frame::capturer::wayland] Detected support for linux-dmabuf-v1 protocol
[2025-01-20T21:55:51Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-export-dmabuf-unstable-v1 protocol
[2025-01-20T21:55:51Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-screencopy-unstable-v1 protocol
[2025-01-20T21:55:51Z DEBUG wluma::frame::capturer::wayland] Using output 'BOE 0x08D5 (eDP-1)' for config 'RTK'
[2025-01-20T21:55:51Z ERROR wluma::frame::capturer::wayland] Cannot use output 'Invalid Vendor Codename - RTK 0x0101 0x01010101 (HDMI-A-1)' for config 'RTK' because another output was already matched with it, skipping this output.
[2025-01-20T21:55:51Z DEBUG wluma::frame::capturer::wayland] Using wlr-screencopy-unstable-v1 protocol to request frames
```

### *Now*:
```bash
[2025-01-20T22:33:06Z DEBUG wluma::brightness::backlight] Using direct write on /sys/class/backlight/amdgpu_bl1 to change brightness 
value
[2025-01-20T22:33:06Z DEBUG wluma::frame::capturer::wayland] Detected support for linux-dmabuf-v1 protocol
[2025-01-20T22:33:06Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-export-dmabuf-unstable-v1 protocol
[2025-01-20T22:33:06Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-screencopy-unstable-v1 protocol
[2025-01-20T22:33:06Z DEBUG wluma::frame::capturer::wayland] Using output 'BOE 0x08D5 (eDP-1)' for config 'BOE'
[2025-01-20T22:33:06Z DEBUG wluma::frame::capturer::wayland] Using wlr-screencopy-unstable-v1 protocol to request frames
[2025-01-20T22:33:09Z DEBUG wluma::brightness::ddcutil] Discovered displays (check_caps=true): ["RTK "]
[2025-01-20T22:33:09Z DEBUG wluma::brightness::ddcutil] Using display 'RTK ' for config 'RTK' (check_caps=true)
[2025-01-20T22:33:09Z INFO  wluma] Continue adjusting brightness and wluma will learn your preference over time.
[2025-01-20T22:33:10Z DEBUG wluma::frame::capturer::wayland] Detected support for linux-dmabuf-v1 protocol
[2025-01-20T22:33:10Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-export-dmabuf-unstable-v1 protocol
[2025-01-20T22:33:10Z DEBUG wluma::frame::capturer::wayland] Detected support for wlr-screencopy-unstable-v1 protocol
[2025-01-20T22:33:10Z DEBUG wluma::frame::capturer::wayland] Using output 'Invalid Vendor Codename - RTK 0x0101 0x01010101 (HDMI-A-1)
' for config 'RTK'
[2025-01-20T22:33:10Z DEBUG wluma::frame::capturer::wayland] Using wlr-screencopy-unstable-v1 protocol to request frames
```