### PR TITLE
als iio: add cros-ec-light

### DIFF
--- a/src/als/iio.rs
+++ b/src/als/iio.rs
@@ -37,7 +37,7 @@ impl Als {
                 smol::fs::read_to_string(entry.path().join("name")).map(|name| (name, entry))
             })
             .filter_map(|(name, entry)| async {
-                ["als", "acpi-als", "apds9960"]
+                ["als", "acpi-als", "apds9960", "cros-ec-light"]
                     .contains(&name.unwrap_or_default().trim())
                     .then_some(entry)
             })


### PR DESCRIPTION
The iio device name of some Chromebooks is `cros-ec-light`.