### PR TITLE
Add support for ALS on Asahi Macs

### DIFF
--- a/src/als/iio.rs
+++ b/src/als/iio.rs
@@ -37,7 +37,7 @@ impl Als {
                 smol::fs::read_to_string(entry.path().join("name")).map(|name| (name, entry))
             })
             .filter_map(|(name, entry)| async {
-                ["als", "acpi-als", "apds9960", "cros-ec-light"]
+                ["als", "acpi-als", "apds9960", "cros-ec-light", "aop-sensors-als"]
                     .contains(&name.unwrap_or_default().trim())
                     .then_some(entry)
             })


### PR DESCRIPTION
With the [recent update](https://asahilinux.org/2026/04/progress-report-7-0/), the ALS is now functional on Asahi devices. It provdes `in_illuminance_input`.