### PR TITLE
Add ASUS keyboard default to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,3 +27,7 @@ path = "/sys/bus/platform/devices/dell-laptop/leds/dell::kbd_backlight"
 # [[keyboard]]
 # name = "keyboard-thinkpad"
 # path = "/sys/bus/platform/devices/thinkpad_acpi/leds/tpacpi::kbd_backlight"
+
+# [[keyboard]]
+# name = "keyboard-asus"
+# path = "/sys/class/leds/asus::kbd_backlight"


### PR DESCRIPTION
ASUS keyboards use a different location for backlight than `/sys/bus/platform/devices`, so this just adds it in the default config