### PR TITLE
Mark SetBrightness D-Bus calls as no-reply to prevent a reply leak that exhausts the user's bus quota

### DIFF
--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -141,11 +141,6 @@ impl Backlight {
                 .duplicate()
                 .map_err(Error::msg)?
                 .append1(value as u32);
-            // SetBrightness has no meaningful return value. Without this flag the
-            // connection is write-only and never drained, so logind's method-return
-            // replies pile up in the bus daemon's outgoing queue indefinitely,
-            // eventually exhausting the per-user message-memory quota and breaking
-            // D-Bus for every other client of the same user.
             message.set_no_reply(true);
             dbus.connection
                 .send(message)

--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -136,13 +136,19 @@ impl Backlight {
         if self.has_write_permission {
             write(&mut self.file, value as f64).await?;
         } else if let Some(dbus) = &self.dbus {
+            let mut message = dbus
+                .message
+                .duplicate()
+                .map_err(Error::msg)?
+                .append1(value as u32);
+            // SetBrightness has no meaningful return value. Without this flag the
+            // connection is write-only and never drained, so logind's method-return
+            // replies pile up in the bus daemon's outgoing queue indefinitely,
+            // eventually exhausting the per-user message-memory quota and breaking
+            // D-Bus for every other client of the same user.
+            message.set_no_reply(true);
             dbus.connection
-                .send(
-                    dbus.message
-                        .duplicate()
-                        .map_err(Error::msg)?
-                        .append1(value as u32),
-                )
+                .send(message)
                 .map_err(|_| anyhow!("Unable to send brightness change message via dbus"))?;
             self.pending_dbus_write = true;
         } else {


### PR DESCRIPTION
## Summary

On the logind D-Bus brightness path (`src/brightness/backlight.rs`, used when wluma lacks direct write permission to the sysfs `brightness` file), wluma sends `SetBrightness` method calls on a `dbus::blocking::Connection` but **never drains the connection** — `process()` / `read_write()` are never called anywhere in the codebase.

A normal method call expects a reply, so logind returns a `method_return` for every `SetBrightness`. Nobody ever reads those replies, so they accumulate without bound in the bus daemon's outgoing queue toward wluma. Because `dbus-broker` accounts message memory **per user**, this slowly consumes the user's entire quota. Once it's exhausted, the bus daemon starts disconnecting that user's *other* clients whenever they request a sizable reply:

```
dbus-broker: Peer :1.NNNN is being disconnected as it does not have the
resources to receive a reply it requested.
```

In practice this manifests as unrelated tools breaking — e.g. `nm-applet` / `nmcli` reporting **"NetworkManager is not running"** even though it is, because `libnm`'s `GetManagedObjects()` reply can no longer be received. Killing wluma (or here, fixing it) immediately frees the quota and the other clients recover. The backed-up socket is directly observable via `ss -xp | grep system_bus_socket` — wluma's connection shows a large, growing `Send-Q`.

## Fix

`SetBrightness` has no meaningful return value, so flag the message as no-reply (`Message::set_no_reply(true)`). logind then never generates a reply and nothing accumulates. Minimal, and keeps the existing fire-and-forget `send()` model.

(An alternative would be to pump the connection with `connection.process(Duration::ZERO)` after each send, but suppressing the reply at the source is cleaner and cheaper.)

## Testing

- `cargo build` succeeds against `dbus 0.9.11` (confirms `set_no_reply` API usage).
- `cargo fmt --check` clean.
- The functional behavior of `SetBrightness` is unchanged; only the now-unused reply is suppressed.